### PR TITLE
Update syntax highlighting for Emacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Current expression syntax can be defined roughly like this:
 <primary> ::= (`(` <expression> `)`) | <application-chain> | <symbol> | <variable>
 <application-chain> ::= (<symbol> | <variable>) (<fun-args>)+
 <symbol> ::= [a-z0-9][_a-zA-Z0-9]*
-<variable> ::= [_A-Z0-9][_a-zA-Z0-9]*
+<variable> ::= [_A-Z][_a-zA-Z0-9]*
 <fun-args> ::= `(` (<expression>),* `)`
 ```
 

--- a/editor/noq-mode.el
+++ b/editor/noq-mode.el
@@ -43,11 +43,26 @@
   "Syntax table for `noq-mode'.")
 
 (eval-and-compile
-  (defconst noq-keywords
-    '("rule" "shape" "apply" "done" "quit" "undo" "reverse" "load")))
+  (defconst noq-apply-strategies
+    '("all" "deep")))
 
 (defconst noq-highlights
-  `((,(regexp-opt noq-keywords 'symbols) . font-lock-keyword-face)))
+  `(
+    ;; `Apply` strategies
+    (,(format "\\(%s\\)[\t ]*|" (mapconcat 'regexp-quote noq-apply-strategies "\\|"))
+     1 'font-lock-keyword-face)
+    ("\\([0-9]+\\)[\t ]*|" 1 'font-lock-keyword-face)
+
+    ;; Variables
+    ;; FIXME: It would be cool if variables were highlighted too (see below). However, there is an
+    ;; issue in that a number can either be a symbol or a variable depending on the context.
+    ;; The regex below works around this by only highlighting variables that don't start with a
+    ;; number, however this obviously won't cover all possible variables.
+    ("[^a-zA-Z0-9_]\\([_A-Z][_a-zA-Z0-9]*\\)" 1 'font-lock-builtin-face)
+
+    ;; Function names
+    ("\\([^\n\| ]*\\)[\t ]*::" 1 'font-lock-function-name-face)
+    ))
 
 ;;;###autoload
 (define-derived-mode noq-mode prog-mode "noq"

--- a/editor/noq-mode.el
+++ b/editor/noq-mode.el
@@ -50,13 +50,13 @@
   `(
     ;; `Apply` strategies
     (,(format "\\(%s\\)[\t ]*|" (mapconcat 'regexp-quote noq-apply-strategies "\\|"))
-     1 'font-lock-keyword-face)
-    ("\\([0-9]+\\)[\t ]*|" 1 'font-lock-keyword-face)
+     1 'font-lock-type-face)
+    ("\\([0-9]+\\)[\t ]*|" 1 'font-lock-type-face)
 
     ;; Variables
-    ("[^a-zA-Z0-9_]\\([_A-Z][_a-zA-Z0-9]*\\)" 1 'font-lock-builtin-face)
+    ("\\(^\\|[^a-zA-Z0-9_]\\)\\([_A-Z][_a-zA-Z0-9]*\\)" 2 'font-lock-variable-name-face)
 
-    ;; Function names
+    ;; Functor names
     ("\\([^\n\| ]*\\)[\t ]*::" 1 'font-lock-function-name-face)
     ))
 

--- a/editor/noq-mode.el
+++ b/editor/noq-mode.el
@@ -54,10 +54,6 @@
     ("\\([0-9]+\\)[\t ]*|" 1 'font-lock-keyword-face)
 
     ;; Variables
-    ;; FIXME: It would be cool if variables were highlighted too (see below). However, there is an
-    ;; issue in that a number can either be a symbol or a variable depending on the context.
-    ;; The regex below works around this by only highlighting variables that don't start with a
-    ;; number, however this obviously won't cover all possible variables.
     ("[^a-zA-Z0-9_]\\([_A-Z][_a-zA-Z0-9]*\\)" 1 'font-lock-builtin-face)
 
     ;; Function names

--- a/editor/noq-mode.el
+++ b/editor/noq-mode.el
@@ -46,8 +46,15 @@
   (defconst noq-apply-strategies
     '("all" "deep")))
 
+(eval-and-compile
+  (defconst noq-keywords
+    '("undo" "quit" "delete" "load")))
+
 (defconst noq-highlights
-  `(
+  `((
+    ;; Keywords
+    ,(regexp-opt noq-keywords 'words) . 'font-lock-keyword-face)
+
     ;; `Apply` strategies
     (,(format "\\(%s\\)[\t ]*|" (mapconcat 'regexp-quote noq-apply-strategies "\\|"))
      1 'font-lock-type-face)


### PR DESCRIPTION
Since the most recent stream was dedicated to bikeshedding the syntax, I've updated the noq-mode.el to reflect the changes!

![image](https://user-images.githubusercontent.com/20472367/162664833-37bff3ac-8a20-44f1-9e19-469fa9faa3c4.png)
![image](https://user-images.githubusercontent.com/20472367/162665081-03bf6a5c-0dfd-4d36-b888-03e7195e1831.png)

Hope you like it! 

