### PR TITLE
Update syntax highlighting

### DIFF
--- a/editor/noq-mode.el
+++ b/editor/noq-mode.el
@@ -56,15 +56,17 @@
     ,(regexp-opt noq-keywords 'words) . 'font-lock-keyword-face)
 
     ;; `Apply` strategies
-    (,(format "\\(%s\\)[\t ]*|" (mapconcat 'regexp-quote noq-apply-strategies "\\|"))
+    (,(format ".*|[\!\t ]*\\(%s\\)" (mapconcat 'regexp-quote noq-apply-strategies "\\|"))
      1 'font-lock-type-face)
-    ("\\([0-9]+\\)[\t ]*|" 1 'font-lock-type-face)
+    (".*|[\!\t ]*\\([0-9]+\\)" 1 'font-lock-type-face)
+    ;; Reverse
+    ("\!" . 'font-lock-keyword-face)
 
     ;; Variables
     ("\\(^\\|[^a-zA-Z0-9_]\\)\\([_A-Z][_a-zA-Z0-9]*\\)" 2 'font-lock-variable-name-face)
 
     ;; Functor names
-    ("\\([^\n\| ]*\\)[\t ]*::" 1 'font-lock-function-name-face)
+    ("\\([^\n\| ]*\\)[!\t ]*::" 1 'font-lock-function-name-face)
     ))
 
 ;;;###autoload


### PR DESCRIPTION
Highlight `reverse` symbol and switch order of rule functor and apply strategy

![image](https://user-images.githubusercontent.com/20472367/163727243-deca34a9-7e45-42f6-bba6-3e7b1ae08f82.png)
