### PR TITLE
Add the unary minus

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -50,6 +50,7 @@ impl<'a> fmt::Display for HighlightedSubexpr<'a> {
                         } else {
                             write!(f, "{}", HighlightedSubexpr{expr: lhs, subexpr})?
                         }
+                        Expr::UnOp(_, _) => write!(f, "({})", HighlightedSubexpr{expr: lhs, subexpr})?,
                         _ => write!(f, "{}", HighlightedSubexpr{expr: lhs, subexpr})?
                     }
                     if op.precedence() <= 1 {
@@ -63,14 +64,17 @@ impl<'a> fmt::Display for HighlightedSubexpr<'a> {
                         } else {
                             write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
                         }
+                        Expr::UnOp(_, _) => write!(f, "({})", HighlightedSubexpr{expr: rhs, subexpr}),
                         _ => write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
                     }
                 },
-                Expr::UnOp(op, expr) => {
-                    write!(f, "{}", op)?;
-                    match **expr {
-                        Expr::Op(_, _, _) | Expr::UnOp(_, _) => write!(f, "({})", expr),
-                        _ => write!(f, "{}", expr)
+                Expr::UnOp(un_op, un_op_expr) => {
+                    write!(f, "{}", un_op)?;
+                    match **un_op_expr {
+                        Expr::Op(_, _, _) | Expr::UnOp(_, _) => {
+                            write!(f, "({})", HighlightedSubexpr{expr: un_op_expr, subexpr})
+                        }
+                        _ => write!(f, "{}", HighlightedSubexpr{expr: un_op_expr, subexpr})
                     }
                 }
             }

--- a/src/command.rs
+++ b/src/command.rs
@@ -65,6 +65,13 @@ impl<'a> fmt::Display for HighlightedSubexpr<'a> {
                         }
                         _ => write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
                     }
+                },
+                Expr::UnOp(op, expr) => {
+                    write!(f, "{}", op)?;
+                    match **expr {
+                        Expr::Op(_, _, _) | Expr::UnOp(_, _) => write!(f, "({})", expr),
+                        _ => write!(f, "{}", expr)
+                    }
                 }
             }
         }

--- a/src/command.rs
+++ b/src/command.rs
@@ -43,14 +43,14 @@ impl<'a> fmt::Display for HighlightedSubexpr<'a> {
                     }
                     write!(f, ")")
                 },
-                Expr::Op(op, lhs, rhs) => {
+                Expr::Op(op, Some(lhs), rhs) => {
                     match **lhs {
-                        Expr::Op(sub_op, _, _) => if sub_op.precedence() <= op.precedence() {
+                        Expr::Op(sub_op, Some(_), _) => if sub_op.precedence() <= op.precedence() {
                             write!(f, "({})", HighlightedSubexpr{expr: lhs, subexpr})?
                         } else {
                             write!(f, "{}", HighlightedSubexpr{expr: lhs, subexpr})?
                         }
-                        Expr::UnOp(_, _) => write!(f, "({})", HighlightedSubexpr{expr: lhs, subexpr})?,
+                        Expr::Op(_, None, _) => write!(f, "{}", HighlightedSubexpr{expr: lhs, subexpr})?,
                         _ => write!(f, "{}", HighlightedSubexpr{expr: lhs, subexpr})?
                     }
                     if op.precedence() <= 1 {
@@ -59,22 +59,20 @@ impl<'a> fmt::Display for HighlightedSubexpr<'a> {
                         write!(f, "{}", op)?;
                     }
                     match **rhs {
-                        Expr::Op(sub_op, _, _) => if sub_op.precedence() <= op.precedence() {
+                        Expr::Op(sub_op, Some(_), _) => if sub_op.precedence() <= op.precedence() {
                             write!(f, "({})", HighlightedSubexpr{expr: rhs, subexpr})
                         } else {
                             write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
                         }
-                        Expr::UnOp(_, _) => write!(f, "({})", HighlightedSubexpr{expr: rhs, subexpr}),
+                        Expr::Op(_, None, _) => write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr}),
                         _ => write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
                     }
                 },
-                Expr::UnOp(un_op, un_op_expr) => {
-                    write!(f, "{}", un_op)?;
-                    match **un_op_expr {
-                        Expr::Op(_, _, _) | Expr::UnOp(_, _) => {
-                            write!(f, "({})", HighlightedSubexpr{expr: un_op_expr, subexpr})
-                        }
-                        _ => write!(f, "{}", HighlightedSubexpr{expr: un_op_expr, subexpr})
+                Expr::Op(op, None, rhs) => {
+                    write!(f, "{}", op)?;
+                    match **rhs {
+                        Expr::Op(_, _, _) => write!(f, "({})", HighlightedSubexpr{expr: rhs, subexpr}),
+                        _ => write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
                     }
                 }
             }

--- a/src/engine/expr.rs
+++ b/src/engine/expr.rs
@@ -241,11 +241,11 @@ impl Expr {
             return Self::parse_primary(lexer, diag)
         }
 
-        if let Some(un_op_token) = UnOp::from_token_kind(lexer.peek_token().kind) {
+        if let Some(un_op) = UnOp::from_token_kind(lexer.peek_token().kind) {
             lexer.next_token();
 
             Some(Expr::UnOp(
-                un_op_token,
+                un_op,
                 Box::new(Self::parse_impl(lexer, current_precedence, diag)?)
             ))
         } else {
@@ -292,6 +292,9 @@ impl Expr {
                 }
                 (Op(op1, lhs1, rhs1), Op(op2, lhs2, rhs2)) => {
                     *op1 == *op2 && pattern_match_impl(lhs1, lhs2, bindings) && pattern_match_impl(rhs1, rhs2, bindings)
+                }
+                (UnOp(un_op1, un_op_expr1), UnOp(un_op2, un_op_expr2)) => {
+                    *un_op1 == *un_op2 && pattern_match_impl(un_op_expr1, un_op_expr2, bindings)
                 }
                 (Fun(name1, args1), Fun(name2, args2)) => {
                     if pattern_match_impl(name1, name2, bindings) && args1.len() == args2.len() {

--- a/src/engine/lexer.rs
+++ b/src/engine/lexer.rs
@@ -52,10 +52,10 @@ pub enum TokenKind {
     CloseCurly,
     Bar,
     Bang,
+    Dash,
 
     // Binary Operators
     Plus,
-    Dash,
     Asterisk,
     Slash,
     Caret,

--- a/src/engine/rule.rs
+++ b/src/engine/rule.rs
@@ -104,6 +104,7 @@ impl Rule {
         }
     }
 
+    //TODO: support for applying rules that have unary minus signs in them
     pub fn apply(&self, expr: &mut Expr, strategy: &Strategy, apply_command_loc: &Loc, diag: &mut impl Diagnoster) -> Option<()> {
         fn apply_to_subexprs(rule: &Rule, expr: &mut Expr, strategy: &Strategy, apply_command_loc: &Loc, match_count: &mut usize, diag: &mut impl Diagnoster) -> Option<bool> {
             match expr {
@@ -114,6 +115,7 @@ impl Rule {
                     }
                     apply_impl(rule, rhs, strategy, apply_command_loc, match_count, diag)
                 }
+                Expr::UnOp(_, _) => todo!(),
                 Expr::Fun(head, args) => {
                     if apply_impl(rule, head, strategy, apply_command_loc, match_count, diag)? {
                         return Some(true);

--- a/src/engine/rule.rs
+++ b/src/engine/rule.rs
@@ -104,7 +104,6 @@ impl Rule {
         }
     }
 
-    //TODO: support for applying rules that have unary minus signs in them
     pub fn apply(&self, expr: &mut Expr, strategy: &Strategy, apply_command_loc: &Loc, diag: &mut impl Diagnoster) -> Option<()> {
         fn apply_to_subexprs(rule: &Rule, expr: &mut Expr, strategy: &Strategy, apply_command_loc: &Loc, match_count: &mut usize, diag: &mut impl Diagnoster) -> Option<bool> {
             match expr {
@@ -115,7 +114,9 @@ impl Rule {
                     }
                     apply_impl(rule, rhs, strategy, apply_command_loc, match_count, diag)
                 }
-                Expr::UnOp(_, _) => todo!(),
+                Expr::UnOp(_, un_op_expr) => {
+                    apply_impl(rule, un_op_expr, strategy, apply_command_loc, match_count, diag)
+                }
                 Expr::Fun(head, args) => {
                     if apply_impl(rule, head, strategy, apply_command_loc, match_count, diag)? {
                         return Some(true);

--- a/src/engine/rule.rs
+++ b/src/engine/rule.rs
@@ -108,14 +108,13 @@ impl Rule {
         fn apply_to_subexprs(rule: &Rule, expr: &mut Expr, strategy: &Strategy, apply_command_loc: &Loc, match_count: &mut usize, diag: &mut impl Diagnoster) -> Option<bool> {
             match expr {
                 Expr::Sym(_) | Expr::Var(_) => Some(false),
-                Expr::Op(_, lhs, rhs) => {
-                    if apply_impl(rule, lhs, strategy, apply_command_loc, match_count, diag)? {
-                        return Some(true)
+                Expr::Op(_, maybe_lhs, rhs) => {
+                    if let Some(lhs) = maybe_lhs {
+                        if apply_impl(rule, lhs, strategy, apply_command_loc, match_count, diag)? {
+                            return Some(true)
+                        }
                     }
                     apply_impl(rule, rhs, strategy, apply_command_loc, match_count, diag)
-                }
-                Expr::UnOp(_, un_op_expr) => {
-                    apply_impl(rule, un_op_expr, strategy, apply_command_loc, match_count, diag)
                 }
                 Expr::Fun(head, args) => {
                     if apply_impl(rule, head, strategy, apply_command_loc, match_count, diag)? {

--- a/src/new_repl.rs
+++ b/src/new_repl.rs
@@ -151,6 +151,7 @@ impl<'a> fmt::Display for HighlightedSubexpr<'a> {
                         } else {
                             write!(f, "{}", HighlightedSubexpr{expr: lhs, subexpr})?
                         }
+                        Expr::UnOp(_, _) => write!(f, "({})", HighlightedSubexpr{expr: lhs, subexpr})?,
                         _ => write!(f, "{}", HighlightedSubexpr{expr: lhs, subexpr})?
                     }
                     if op.precedence() <= 1 {
@@ -164,7 +165,17 @@ impl<'a> fmt::Display for HighlightedSubexpr<'a> {
                         } else {
                             write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
                         }
+                        Expr::UnOp(_, _) => write!(f, "({})", HighlightedSubexpr{expr: rhs, subexpr}),
                         _ => write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
+                    }
+                }
+                Expr::UnOp(un_op, un_op_expr) => {
+                    write!(f, "{}", un_op)?;
+                    match **un_op_expr {
+                        Expr::UnOp(_, _) | Expr::Op(_, _, _) => {
+                            write!(f, "({})", HighlightedSubexpr{expr: un_op_expr, subexpr}),
+                        }
+                        _ => write!(f, "{}", HighlightedSubexpr{expr: un_op_expr, subexpr})
                     }
                 }
             }

--- a/src/new_repl.rs
+++ b/src/new_repl.rs
@@ -144,14 +144,14 @@ impl<'a> fmt::Display for HighlightedSubexpr<'a> {
                     }
                     write!(f, ")")
                 },
-                Expr::Op(op, lhs, rhs) => {
+                Expr::Op(op, Some(lhs), rhs) => {
                     match **lhs {
-                        Expr::Op(sub_op, _, _) => if sub_op.precedence() <= op.precedence() {
+                        Expr::Op(sub_op, Some(_), _) => if sub_op.precedence() <= op.precedence() {
                             write!(f, "({})", HighlightedSubexpr{expr: lhs, subexpr})?
                         } else {
                             write!(f, "{}", HighlightedSubexpr{expr: lhs, subexpr})?
                         }
-                        Expr::UnOp(_, _) => write!(f, "({})", HighlightedSubexpr{expr: lhs, subexpr})?,
+                        Expr::Op(_, None, _) => write!(f, "{}", HighlightedSubexpr{expr: lhs, subexpr})?,
                         _ => write!(f, "{}", HighlightedSubexpr{expr: lhs, subexpr})?
                     }
                     if op.precedence() <= 1 {
@@ -160,22 +160,20 @@ impl<'a> fmt::Display for HighlightedSubexpr<'a> {
                         write!(f, "{}", op)?;
                     }
                     match **rhs {
-                        Expr::Op(sub_op, _, _) => if sub_op.precedence() <= op.precedence() {
+                        Expr::Op(sub_op, Some(_), _) => if sub_op.precedence() <= op.precedence() {
                             write!(f, "({})", HighlightedSubexpr{expr: rhs, subexpr})
                         } else {
                             write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
                         }
-                        Expr::UnOp(_, _) => write!(f, "({})", HighlightedSubexpr{expr: rhs, subexpr}),
+                        Expr::Op(_, None, _) => write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr}),
                         _ => write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
                     }
-                }
-                Expr::UnOp(un_op, un_op_expr) => {
-                    write!(f, "{}", un_op)?;
-                    match **un_op_expr {
-                        Expr::UnOp(_, _) | Expr::Op(_, _, _) => {
-                            write!(f, "({})", HighlightedSubexpr{expr: un_op_expr, subexpr}),
-                        }
-                        _ => write!(f, "{}", HighlightedSubexpr{expr: un_op_expr, subexpr})
+                },
+                Expr::Op(op, None, rhs) => {
+                    write!(f, "{}", op)?;
+                    match **rhs {
+                        Expr::Op(_, _, _) => write!(f, "({})", HighlightedSubexpr{expr: rhs, subexpr}),
+                        _ => write!(f, "{}", HighlightedSubexpr{expr: rhs, subexpr})
                     }
                 }
             }


### PR DESCRIPTION
a unary minus can be thought of as a subtraction with only a right hand side expression (so `-1` can be thought of as `None - 1`. because of that, to implement the unary minus, the `lhs` field of the `Op` in `Expr` was made optional